### PR TITLE
chore: remove instance options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madronejs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Object composition and reactivity framework.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madronejs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Object composition and reactivity framework.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madronejs",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "description": "Object composition and reactivity framework.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -146,7 +146,12 @@ const Model = {
         compileShape();
         compileOptions();
 
+        const pluginList = allPlugins();
+        const modelOptions = { ...model.options };
         let ctx = {} as MadroneType;
+
+        // remove all options that have been installed as plugins
+        pluginList.forEach((pl) => Reflect.deleteProperty(modelOptions, pl.name));
 
         Object.defineProperties(ctx, {
           ...MadronePrototypeDescriptors,
@@ -154,7 +159,7 @@ const Model = {
             $state: undefined,
             $isMadrone: true,
             $parent: parent,
-            $options: model.options,
+            $options: modelOptions,
             $model: model,
             $models: {},
             $modelType: model.type,
@@ -176,7 +181,7 @@ const Model = {
           ctx.$state = pl.integrate(ctx);
         }
 
-        installPlugins(ctx, optionCache, allPlugins());
+        installPlugins(ctx, optionCache, pluginList);
 
         if (typeof ctx.$init === 'function') {
           ctx = ctx.$init(data) || ctx;

--- a/src/__spec__/Madrone.spec.js
+++ b/src/__spec__/Madrone.spec.js
@@ -45,4 +45,20 @@ describe('$createNode', () => {
     expect(myTestInstance.bar).toEqual(true);
     expect(myTestInstance.$parent).toEqual(instance);
   });
+
+  it('removes installed plugins from $options', () => {
+    const model = Madrone.Model.create({
+      $options: {
+        test: false,
+      },
+      foo: true,
+      get bar() {
+        return this.foo;
+      },
+    });
+    const instance = model.create();
+
+    expect(Object.keys(model.options)).toEqual(['test', 'computed', 'data']);
+    expect(Object.keys(instance.$options)).toEqual(['test']);
+  });
 });


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
| `perf`      | Things are faster now!                                                    |  🚀  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- Remove plugins from the instance $options

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
When working in Vue, the $options are used to determine what shows up in the developer tools. This causes all of the computed properties to be evaluated when Vue stringifies objects to be passed between the app and the dev tools panel, which slows everything down quite a bit. This PR removes the installed plugins (computed, data, methods... etc) from the $options on each instance. The rest of the options are available via `myInstance.$model.options`.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
