### PR TITLE
chore: extend object instead of any

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -21,7 +21,8 @@ const Model = {
    * Create a factory model
    * @param shape The shape to create a model for
    */
-  create: function create<ModelShape>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  create: function create<ModelShape extends object>(
     shape: (ModelShape | MadroneType) | (() => ModelShape | MadroneType)
   ) {
     /** Unique model identifier */
@@ -94,7 +95,8 @@ const Model = {
       return shapeCache;
     };
     /** Extend a model definition by creating a new one */
-    const extend = <A extends any>(newShape: A | ModelShape | MadroneType) => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const extend = <A extends object>(newShape: A | ModelShape | MadroneType) => {
       if (Model.isModel(newShape)) {
         return create(() => merge(getShape, () => (newShape as { type: A }).type) as A & ModelShape)
           .withOptions(getOptions)

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,8 @@ export type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R
  * @param types
  * @returns The new object definition
  */
-export function merge<A extends any[]>(...types: [...A]) {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function merge<A extends object[]>(...types: [...A]) {
   const defs = {} as PropertyDescriptorMap;
   const newVal = {};
 


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- use `object` type instead of `any`

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
This helps with type definitions when viewing in typescript files.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
