### PR TITLE
chore: remove $parent and $root

### DIFF
--- a/src/Madrone.ts
+++ b/src/Madrone.ts
@@ -14,10 +14,7 @@ const MadronePrototype = {
   $options: undefined,
   /** Hook into the initialization process */
   $init: undefined as (...any) => any,
-  /**
-   * The application this node is a part of
-   * @deprecated
-   */
+  /** The application this node is a part of */
   $app: undefined,
   /** Hold other model definitions for ease of use */
   $models: undefined,
@@ -39,8 +36,6 @@ const MadronePrototype = {
 
     return newModel?.create?.(data, {
       app: this.$app,
-      root: this.$root,
-      parent: this,
       ...(options || {}),
     });
   },

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -144,7 +144,7 @@ const Model = {
         return model;
       },
       /** Create an instance of this model type */
-      create(data?: any, { app = null, root = null, parent = null } = {}) {
+      create(data?: any, { app = null } = {}) {
         compileShape();
         compileOptions();
 
@@ -160,18 +160,14 @@ const Model = {
           ...getDefaultDescriptors({
             $state: undefined,
             $isMadrone: true,
-            $parent: parent,
             $options: modelOptions,
             $model: model,
             $models: {},
             $modelType: model.type,
             $dataSet: new Set(),
-            get $root() {
-              return root || parent || ctx;
-            },
             get $app() {
               // @ts-ignore
-              return app || ctx.$root;
+              return app || ctx;
             },
           }),
         });

--- a/src/__spec__/Madrone.spec.js
+++ b/src/__spec__/Madrone.spec.js
@@ -27,7 +27,6 @@ describe('$createNode', () => {
     expect(Madrone.isMadrone(myTestInstance)).toEqual(true);
     expect(myTestInstance.foo).toEqual(true);
     expect(myTestInstance.bar).toEqual(true);
-    expect(myTestInstance.$parent).toEqual(instance);
   });
 
   it('can create instances from functions that return models', () => {
@@ -43,7 +42,6 @@ describe('$createNode', () => {
     expect(Madrone.isMadrone(myTestInstance)).toEqual(true);
     expect(myTestInstance.foo).toEqual(true);
     expect(myTestInstance.bar).toEqual(true);
-    expect(myTestInstance.$parent).toEqual(instance);
   });
 
   it('removes installed plugins from $options', () => {

--- a/src/plugins/__spec__/Models.spec.js
+++ b/src/plugins/__spec__/Models.spec.js
@@ -15,7 +15,6 @@ describe('Models', () => {
     const instance = model2.create();
     const node = instance.$createNode('model1');
 
-    expect(node.$parent).toEqual(instance);
     expect(node.foo).toEqual(true);
     expect(node.bar).toEqual(false);
   });
@@ -43,7 +42,6 @@ describe('Models', () => {
     const instance = model.create();
     const node = instance.$createNode('test');
 
-    expect(node.$parent).toEqual(instance);
     expect(node.foo).toEqual(true);
     expect(node.bar).toEqual(true);
     expect(node.foo2).toBeUndefined();
@@ -52,7 +50,6 @@ describe('Models', () => {
     const instance2 = model2.create();
     const node2 = instance2.$createNode('test');
 
-    expect(node2.$parent).toEqual(instance2);
     expect(node2.foo).toBeUndefined();
     expect(node2.bar).toBeUndefined();
     expect(node2.foo2).toEqual(false);


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- remove `$root` because `$app` can do the same thing
- remove `$parent` because it encourages bad patterns

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
Continuing down the cleanup path, remove `$parent` and `$root`

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
