### PR TITLE
chore: class accessors are enumerable

### DIFF
--- a/src/decorate.ts
+++ b/src/decorate.ts
@@ -30,6 +30,8 @@ function computedIfNeeded(target: any, key: string, descriptor: PropertyDescript
       pl?.describeComputed?.(key, {
         ...descriptor,
         get: descriptor.get.bind(target),
+        set: descriptor.set?.bind(target),
+        enumerable: true,
         cache: true,
       }) || descriptor
     );
@@ -44,12 +46,16 @@ function computedIfNeeded(target: any, key: string, descriptor: PropertyDescript
 
 export function computed(target: any, key: string, descriptor: PropertyDescriptor) {
   if (typeof descriptor.get === 'function') {
-    const newDescriptor = { ...descriptor, configurable: true };
+    const newDescriptor = { ...descriptor, enumerable: true, configurable: true };
 
     newDescriptor.get = function computedGetter() {
       computedIfNeeded(this, key, descriptor);
-
       return this[key];
+    };
+
+    newDescriptor.set = function computedSetter(val) {
+      computedIfNeeded(this, key, descriptor);
+      this[key] = val;
     };
 
     return newDescriptor;

--- a/src/integrations/__spec__/testClass.ts
+++ b/src/integrations/__spec__/testClass.ts
@@ -30,6 +30,15 @@ export default function testClass(name, integration) {
         this._test?.();
         return `${this.name} ${this.age}`;
       }
+
+      @reactive _getterSetter: any;
+      @computed get getterSetter() {
+        return this._getterSetter;
+      }
+
+      set getterSetter(val) {
+        this._getterSetter = val;
+      }
     }
 
     it('makes accessed properties enumerable', () => {
@@ -54,6 +63,22 @@ export default function testClass(name, integration) {
       expect(fooInstance.summary).toEqual('test2 10');
       expect(fooInstance.summary).toEqual('test2 10');
       expect(calls).toEqual(2);
+    });
+
+    it('can get/set computed', () => {
+      const fooInstance = Foo.create();
+
+      expect(fooInstance.getterSetter).toEqual(undefined);
+      fooInstance.getterSetter = 'test!';
+      expect(fooInstance.getterSetter).toEqual('test!');
+    });
+
+    it('accessed computed is enumerable', () => {
+      const fooInstance = Foo.create();
+
+      fooInstance.getterSetter = 'test!';
+
+      expect(Object.keys(fooInstance)).toEqual(['name', 'age', 'getterSetter', '_getterSetter']);
     });
 
     it('watches data', async () => {


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- fix setters not binding correctly
- make getters enumerable

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [ ] Assigned PR to myself
- [ ] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
