### PR TITLE
chore: static create in $createNode to help migrate

### DIFF
--- a/src/Madrone.ts
+++ b/src/Madrone.ts
@@ -31,6 +31,10 @@ const MadronePrototype = {
     }
 
     if (typeof newModel === 'function') {
+      if (typeof newModel.create === 'function') {
+        return newModel.create(data);
+      }
+
       newModel = newModel() || newModel;
     }
 

--- a/src/integrations/__spec__/testCreateNode.js
+++ b/src/integrations/__spec__/testCreateNode.js
@@ -44,5 +44,26 @@ export default function testData(name, integration) {
       expect(instance.foo).toEqual('foo');
       expect(instance.bar).toEqual('bar');
     });
+
+    it('creates from class with static "create" method', () => {
+      class TestClass {
+        static create(data) {
+          return new TestClass(data);
+        }
+
+        constructor({ foo, bar }) {
+          this.foo = foo;
+          this.bar = bar;
+          this.itWorked = true;
+        }
+      }
+
+      const model = Madrone.Model.create({});
+      const instance = model.create().$createNode(TestClass, { foo: 'foo', bar: 'bar' });
+
+      expect(instance.foo).toEqual('foo');
+      expect(instance.bar).toEqual('bar');
+      expect(instance.itWorked).toEqual(true);
+    });
   });
 }


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- `$createNode` can use a static `create` method if it exists

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
This will make it easier to use functions/classes with static methods instead of Madrone models

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
