### PR TITLE
chore: last access time

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,7 +1,7 @@
-import { getIntegration } from './global';
-import { MadroneDescriptor } from './interfaces/Integration';
+import { getIntegration } from '@/global';
+import { MadroneDescriptor } from '@/interfaces';
 
-export function define<T>(obj: T, key: string, descriptor: MadroneDescriptor) {
+export function define<T extends object>(obj: T, key: string, descriptor: MadroneDescriptor) {
   const pl = getIntegration();
 
   if (!pl) {
@@ -10,7 +10,7 @@ export function define<T>(obj: T, key: string, descriptor: MadroneDescriptor) {
 
   if (typeof descriptor.get === 'function' && pl?.defineComputed) {
     pl.defineComputed(obj, key, {
-      get: descriptor.get?.bind(obj),
+      get: descriptor.get.bind(obj),
       set: descriptor.set?.bind(obj),
       enumerable: descriptor.enumerable,
       configurable: descriptor.configurable,
@@ -25,9 +25,13 @@ export function define<T>(obj: T, key: string, descriptor: MadroneDescriptor) {
   }
 }
 
-export function auto<T>(obj: T, objDescriptors?: { [K in keyof T]?: MadroneDescriptor }) {
+export function auto<T extends object>(
+  obj: T,
+  objDescriptors?: { [K in keyof T]?: MadroneDescriptor }
+) {
   const descriptors = Object.getOwnPropertyDescriptors(obj);
-  const getDesc = (name, descName) => objDescriptors?.[name]?.[descName];
+  const getDesc = (name: string, descName: keyof MadroneDescriptor) =>
+    objDescriptors?.[name]?.[descName];
 
   Object.entries(descriptors).forEach(([key, descriptor]) => {
     define(obj, key, {

--- a/src/decorate.ts
+++ b/src/decorate.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { getIntegration } from './global';
-import { applyClassMixins } from './util';
+import { getIntegration } from '@/global';
+import { applyClassMixins } from '@/util';
+import { define } from '@/auto';
 
 const itemMap: WeakMap<any, Set<string>> = new WeakMap();
 
@@ -32,18 +33,13 @@ function computedIfNeeded(target: any, key: string, descriptor: PropertyDescript
   const pl = getIntegration();
 
   if (pl && !checkTargetObserved(target, key)) {
-    Object.defineProperty(
-      target,
-      key,
-      pl?.describeComputed?.(key, {
-        ...descriptor,
-        get: descriptor.get.bind(target),
-        set: descriptor.set?.bind(target),
-        enumerable: true,
-        cache: true,
-      }) || descriptor
-    );
-
+    define(target, key, {
+      ...descriptor,
+      get: descriptor.get.bind(target),
+      set: descriptor.set?.bind(target),
+      enumerable: true,
+      cache: true,
+    });
     setTargetObserved(target, key);
     return true;
   }
@@ -83,13 +79,8 @@ function reactiveIfNeeded(target: any, key: string, value?: any) {
 
   if (pl && !checkTargetObserved(target, key)) {
     const descriptor = Object.getOwnPropertyDescriptor(target, key);
-    const modified = pl?.describeProperty?.(key, {
-      ...descriptor,
-      enumerable: true,
-      value,
-    });
 
-    Object.defineProperty(target, key, modified || descriptor);
+    define(target, key, { ...descriptor, enumerable: true, value });
     setTargetObserved(target, key);
     return true;
   }

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,9 @@
 import { Integration } from '@/interfaces';
 
+// /////////////////////////////////
+// INTEGRATIONS
+// /////////////////////////////////
+
 const GLOBAL_INTEGRATIONS = new Set<Integration>();
 let CURRENT_INTEGRATION: Integration;
 
@@ -31,4 +35,25 @@ export function removeIntegration(integration) {
 
 export function getIntegration() {
   return CURRENT_INTEGRATION;
+}
+
+// /////////////////////////////////
+// STATS
+// /////////////////////////////////
+
+const STATS_ACCESS = new WeakMap<object, number>();
+
+export function toRaw<T>(obj: T) {
+  const getRawItem = getIntegration()?.toRaw ?? (() => obj);
+
+  return getRawItem(obj);
+}
+
+export function objectAccessed(obj: object) {
+  STATS_ACCESS.set(toRaw(obj), Date.now());
+}
+
+/** The last time any reactive property was accessed on a given object */
+export function lastAccessed(obj: object) {
+  return STATS_ACCESS.get(toRaw(obj));
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,4 +1,4 @@
-import { Integration } from './interfaces';
+import { Integration } from '@/interfaces';
 
 const GLOBAL_INTEGRATIONS = new Set<Integration>();
 let CURRENT_INTEGRATION: Integration;

--- a/src/global.ts
+++ b/src/global.ts
@@ -43,12 +43,14 @@ export function getIntegration() {
 
 const STATS_ACCESS = new WeakMap<object, number>();
 
+/** Get the raw value of an object (without the proxy) */
 export function toRaw<T>(obj: T) {
   const getRawItem = getIntegration()?.toRaw ?? (() => obj);
 
   return getRawItem(obj);
 }
 
+/** Mark an object as accessed */
 export function objectAccessed(obj: object) {
   STATS_ACCESS.set(toRaw(obj), Date.now());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { addIntegration, removeIntegration } from './global';
-import { auto, define, watch } from './auto';
-import { MadroneState } from './integrations';
+import { addIntegration, removeIntegration, lastAccessed } from '@/global';
+import { auto, define, watch } from '@/auto';
+import { MadroneState } from '@/integrations';
 
 addIntegration(MadroneState);
 
@@ -18,6 +18,8 @@ const Madrone = {
   define,
   /** Watch reactive objects */
   watch,
+  /** Get the last time any reactive property was touched on a given object */
+  lastAccessed,
 };
 
 export default Madrone;

--- a/src/integrations/MadroneVue2.ts
+++ b/src/integrations/MadroneVue2.ts
@@ -1,3 +1,4 @@
+import { objectAccessed } from '@/global';
 import * as MadroneState from './MadroneState';
 
 export default ({ observable, set }) => {
@@ -71,6 +72,7 @@ export default ({ observable, set }) => {
     },
     reactive: {
       onGet: ({ target, key }) => {
+        objectAccessed(target);
         depend(target, key);
       },
       onHas: ({ target }) => {

--- a/src/integrations/__spec__/testAccess.ts
+++ b/src/integrations/__spec__/testAccess.ts
@@ -1,0 +1,51 @@
+/* eslint-disable max-classes-per-file */
+import Madrone, { computed, reactive } from '../../index';
+
+export default function testClass(integrationName, integration) {
+  beforeAll(() => {
+    Madrone.use(integration);
+  });
+  afterAll(() => {
+    Madrone.unuse(integration);
+  });
+
+  it('makes person factory', async () => {
+    const PersonFactory = ({ name = undefined } = {}) =>
+      Madrone.auto({
+        name,
+        // when using reactivity integration, getters become cached computeds
+        get greeting() {
+          return `Hi, I'm ${this.name}`;
+        },
+      });
+
+    const person = PersonFactory({ name: 'Greg' });
+
+    expect(Madrone.lastAccessed(person)).toBeUndefined();
+    expect(person.name).toEqual('Greg');
+
+    expect(typeof Madrone.lastAccessed(person)).toEqual('number');
+  });
+
+  it('makes person class', async () => {
+    class Person {
+      @reactive name;
+      @reactive age;
+
+      @computed get greeting() {
+        return `Hi, I'm ${this.name}`;
+      }
+
+      constructor(options) {
+        this.name = options?.name;
+        this.age = options?.age;
+      }
+    }
+
+    const person = new Person({ name: 'Greg' });
+
+    expect(Madrone.lastAccessed(person)).toBeUndefined();
+    expect(person.name).toEqual('Greg');
+    expect(typeof Madrone.lastAccessed(person)).toEqual('number');
+  });
+}

--- a/src/integrations/__spec__/testAll.ts
+++ b/src/integrations/__spec__/testAll.ts
@@ -1,10 +1,12 @@
 import omit from 'lodash/omit';
 import auto from './testAuto';
 import testClass from './testClass';
+import testAccess from './testAccess';
 
 const testObj = {
   auto,
   testClass,
+  testAccess,
 };
 
 export default function testAll(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@ export interface MadroneDescriptorMap {
   [key: string]: MadroneDescriptor;
 }
 
-export default interface Integration {
+export interface Integration {
   defineProperty: (
     target: any,
     name: string,
@@ -29,6 +29,7 @@ export default interface Integration {
     },
     options?: any
   ) => any;
+  toRaw?: <T>(target: T) => T;
   watch?: <T>(
     scope: () => any,
     handler: (val: T, old?: T) => any,

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,0 @@
-export { default as Integration } from './Integration'; // eslint-disable-line import/prefer-default-export

--- a/src/reactivity/global.ts
+++ b/src/reactivity/global.ts
@@ -29,6 +29,8 @@ export const getReactive = (target) => TARGET_TO_PROXY.get(target);
 export const getTarget = (tracker) => PROXY_TO_TARGET.get(tracker);
 export const getProxy = (targetOrProxy) =>
   isReactive(targetOrProxy) ? targetOrProxy : getReactive(targetOrProxy);
+export const toRaw = (targetOrProxy) =>
+  isReactive(targetOrProxy) ? getTarget(targetOrProxy) : targetOrProxy;
 
 export const getDependencies = (observer) => OBSERVER_TO_PROXIES.get(observer);
 /** Get the list of items that are observing a given proxy */

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,3 +1,4 @@
 export { default as Computed } from './Computed';
 export { default as Reactive } from './Reactive';
 export { default as Watcher } from './Watcher';
+export { toRaw } from './global';


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- for a given node, get the last time a reactive property was accessed

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
