### PR TITLE
chore: configurable decorators

### DIFF
--- a/src/__spec__/decorateComputed.spec.ts
+++ b/src/__spec__/decorateComputed.spec.ts
@@ -1,0 +1,84 @@
+/* eslint-disable max-classes-per-file */
+import { computed } from '../index';
+
+describe('computed decorator', () => {
+  describe('enumerable', () => {
+    it('makes properties enumerable by default', () => {
+      class Test {
+        @computed get test() {
+          return true;
+        }
+      }
+
+      const instance = new Test();
+
+      expect(instance.test).toEqual(true);
+      expect(Object.keys(instance)).toEqual(['test']);
+    });
+
+    it('can make properties non-enumerable', () => {
+      class Test {
+        @computed.configure({ enumerable: false })
+        get test() {
+          return true;
+        }
+      }
+
+      const instance = new Test();
+
+      expect(instance.test).toEqual(true);
+      expect(Object.keys(instance)).toEqual([]);
+    });
+  });
+
+  describe('configurable', () => {
+    it('makes properties configurable by default', () => {
+      class Test {
+        @computed get test() {
+          return true;
+        }
+      }
+
+      const instance = new Test();
+      let error: Error;
+
+      expect(instance.test).toEqual(true);
+
+      try {
+        // attempt to redefine property
+        Object.defineProperty(instance, 'test', {
+          configurable: true,
+        });
+      } catch (error_) {
+        error = error_;
+      }
+
+      expect(error?.message).toBeUndefined();
+    });
+
+    it('can make properties non-configurable', () => {
+      class Test {
+        @computed.configure({ configurable: false })
+        get test() {
+          return true;
+        }
+      }
+
+      const instance = new Test();
+      let error: Error;
+
+      expect(instance.test).toEqual(true);
+
+      try {
+        // attempt to redefine property
+        Object.defineProperty(instance, 'test', {
+          configurable: true,
+        });
+      } catch (error_) {
+        error = error_;
+      }
+
+      expect(error?.message).toEqual('Cannot redefine property: test');
+    });
+  });
+});

--- a/src/__spec__/decorateReactive.spec.ts
+++ b/src/__spec__/decorateReactive.spec.ts
@@ -1,0 +1,91 @@
+/* eslint-disable max-classes-per-file */
+import { reactive } from '../index';
+
+describe('reactive decorator', () => {
+  describe('enumerable', () => {
+    it('makes properties enumerable by default', () => {
+      class Test {
+        @reactive test: boolean;
+
+        constructor() {
+          this.test = true;
+        }
+      }
+
+      const instance = new Test();
+
+      expect(instance.test).toEqual(true);
+      expect(Object.keys(instance)).toEqual(['test']);
+    });
+
+    it('can make properties non-enumerable', () => {
+      class Test {
+        @reactive.configure({ enumerable: false })
+        test: boolean;
+
+        constructor() {
+          this.test = true;
+        }
+      }
+
+      const instance = new Test();
+
+      expect(instance.test).toEqual(true);
+      expect(Object.keys(instance)).toEqual([]);
+    });
+  });
+
+  describe('configurable', () => {
+    it('makes properties non-configurable by default', () => {
+      class Test {
+        @reactive test: boolean;
+
+        constructor() {
+          this.test = true;
+        }
+      }
+
+      const instance = new Test();
+      let error: Error;
+
+      expect(instance.test).toEqual(true);
+
+      try {
+        // attempt to redefine property
+        Object.defineProperty(instance, 'test', {
+          configurable: true,
+        });
+      } catch (error_) {
+        error = error_;
+      }
+
+      expect(error?.message).toEqual('Cannot redefine property: test');
+    });
+
+    it('can make properties configurable', () => {
+      class Test {
+        @reactive.configure({ configurable: true }) test: boolean;
+
+        constructor() {
+          this.test = true;
+        }
+      }
+
+      const instance = new Test();
+      let error: Error;
+
+      expect(instance.test).toEqual(true);
+
+      try {
+        // attempt to redefine property
+        Object.defineProperty(instance, 'test', {
+          configurable: true,
+        });
+      } catch (error_) {
+        error = error_;
+      }
+
+      expect(error?.message).toBeUndefined();
+    });
+  });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,6 +6,14 @@ export interface MadroneDescriptorMap {
   [key: string]: MadroneDescriptor;
 }
 
+export type DecoratorDescriptorType = Omit<
+  PropertyDescriptor,
+  'get' | 'set' | 'writable' | 'value'
+>;
+export type DecoratorOptionType = {
+  descriptors?: DecoratorDescriptorType;
+};
+
 export interface Integration {
   defineProperty: (
     target: any,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "experimentalDecorators": true,
+    "skipLibCheck": true,
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- add the ability to configure the descriptors on properties and accessors defined using decorators
- fix npm package preventing types from building successfully

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
This makes it possible to define a property and set its descriptors using decorators.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
