### PR TITLE
fix: array reactivity

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,5 +1,5 @@
 import { getIntegration } from '@/global';
-import { MadroneDescriptor } from '@/interfaces';
+import { MadroneDescriptor, WatcherOptions } from '@/interfaces';
 
 export function define<T extends object>(obj: T, key: string, descriptor: MadroneDescriptor) {
   const pl = getIntegration();
@@ -50,7 +50,7 @@ export function auto<T extends object>(
 export function watch<T>(
   scope: () => T,
   handler: (val: T, old: T) => any,
-  options?: { deep?: boolean }
+  options?: WatcherOptions
 ) {
   const pl = getIntegration();
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,6 +14,11 @@ export type DecoratorOptionType = {
   descriptors?: DecoratorDescriptorType;
 };
 
+export type WatcherOptions = {
+  deep?: boolean;
+  immediate?: boolean;
+};
+
 export interface Integration {
   defineProperty: (
     target: any,
@@ -41,7 +46,7 @@ export interface Integration {
   watch?: <T>(
     scope: () => any,
     handler: (val: T, old?: T) => any,
-    options?: { deep?: boolean }
+    options?: WatcherOptions
   ) => () => void;
   describeComputed?: (name: string, config: MadroneDescriptor, options?: any) => PropertyDescriptor;
   describeProperty?: (

--- a/src/reactivity/Watcher.ts
+++ b/src/reactivity/Watcher.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
+import { WatcherOptions } from '@/interfaces';
 import Observer from './Observer';
 
 /**
@@ -11,10 +12,7 @@ import Observer from './Observer';
 export default function Watcher<T>(
   get: () => T,
   handler: (val?: T, old?: T) => any,
-  options?: {
-    deep?: boolean;
-    immediate?: boolean;
-  }
+  options?: WatcherOptions
 ) {
   let getter = get;
 

--- a/src/reactivity/__spec__/observer_array.spec.ts
+++ b/src/reactivity/__spec__/observer_array.spec.ts
@@ -2,6 +2,19 @@ import Observer from '../Observer';
 import Reactive from '../Reactive';
 
 describe('array', () => {
+  it('calls onGet on spread (...)', () => {
+    let counter = 0;
+    const object = ['one', 'two'];
+    const tracked = Reactive(object, {
+      onGet: () => {
+        counter += 1;
+      },
+    });
+
+    expect([...tracked]).toEqual(object);
+    expect(counter).toBeGreaterThan(1);
+  });
+
   it('busts cache on array set', () => {
     let counter = 0;
     const array = [];

--- a/src/reactivity/typeHandlers.ts
+++ b/src/reactivity/typeHandlers.ts
@@ -45,15 +45,20 @@ const optionGet = (options: ReactiveOptions, target, key, receiver) => {
 };
 const optionSet = (options: ReactiveOptions, target, key, value) => {
   const curr = target[key];
+  const isArray = Array.isArray(target);
   let valueChanged = false;
   let keysChanged = false;
 
   if (!(key in target)) {
     targetChanged(target, KEYS_SYMBOL);
     keysChanged = true;
+
+    if (isArray) {
+      targetChanged(target, 'length');
+    }
   }
 
-  if (curr !== value || Array.isArray(target)) {
+  if (curr !== value || isArray) {
     targetChanged(target, key);
     valueChanged = true;
   }
@@ -114,6 +119,7 @@ function defaultHandlers(options: ReactiveOptions) {
       return value;
     },
     set: (target: object, propertyKey: PropertyKey, value: any) => {
+      console.log('set', propertyKey);
       optionSet(options, target, propertyKey, value);
       return Reflect.set(target, propertyKey, value);
     },

--- a/src/reactivity/typeHandlers.ts
+++ b/src/reactivity/typeHandlers.ts
@@ -119,7 +119,6 @@ function defaultHandlers(options: ReactiveOptions) {
       return value;
     },
     set: (target: object, propertyKey: PropertyKey, value: any) => {
-      console.log('set', propertyKey);
       optionSet(options, target, propertyKey, value);
       return Reflect.set(target, propertyKey, value);
     },


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `fix`       | Fixes an issue                                                            |  🐛  |    ✅     |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- fix reactivity when changing values in an array directly

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
Found an edge case where updating an array directly like `array[3] = 'newVal'` wouldn't cause a reactivity update. This should resolve that issue. Also found that the watcher options didn't match the implementation, so fix that while I'm here.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
