### PR TITLE
chore: expose toRaw, add shallow reactive

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -21,6 +21,7 @@ export function define<T extends object>(obj: T, key: string, descriptor: Madron
       value: descriptor.value,
       enumerable: descriptor.enumerable,
       configurable: descriptor.configurable,
+      deep: descriptor.deep,
     });
   }
 }
@@ -41,6 +42,7 @@ export function auto<T extends object>(
       enumerable: getDesc(key, 'enumerable') ?? descriptor.enumerable,
       configurable: getDesc(key, 'configurable') ?? descriptor.configurable,
       cache: getDesc(key, 'cache') ?? true,
+      deep: getDesc(key, 'deep') ?? true,
     });
   }
 

--- a/src/decorate.ts
+++ b/src/decorate.ts
@@ -148,6 +148,15 @@ function decorateReactive(target: any, key: string, options?: DecoratorOptionTyp
   }
 }
 
+interface reactive extends Function {
+  /** Create a shallow reactive property */
+  shallow: (target: any, key: string) => ReturnType<typeof decorateReactive>;
+  /** Configure the descriptors for a property */
+  configure: (
+    overrides: DecoratorDescriptorType
+  ) => (target: any, key: string) => ReturnType<typeof decorateReactive>;
+}
+
 /**
  * Configure a reactive property
  * @param target The target to add the reactive property to
@@ -156,6 +165,10 @@ function decorateReactive(target: any, key: string, options?: DecoratorOptionTyp
 export function reactive(target: any, key: string) {
   return decorateReactive(target, key);
 }
+
+reactive.shallow = function configureReactive(target: any, key: string) {
+  return decorateReactive(target, key, { descriptors: { deep: false } });
+};
 
 reactive.configure = function configureReactive(descriptorOverrides: DecoratorDescriptorType) {
   return (target: any, key: string) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,6 @@ const Madrone = {
 export default Madrone;
 export * from './integrations';
 export * from './decorate';
+export { toRaw } from '@/global';
 export { merge, applyClassMixins } from './util';
 export { watch, auto } from '@/auto';

--- a/src/integrations/MadroneState.ts
+++ b/src/integrations/MadroneState.ts
@@ -1,5 +1,5 @@
 import { objectAccessed } from '@/global';
-import { MadroneDescriptor } from '@/interfaces';
+import { MadroneComputedDescriptor, MadronePropertyDescriptor } from '@/interfaces';
 import { Computed, Reactive, Watcher, toRaw } from '@/reactivity';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
@@ -11,7 +11,7 @@ type MadroneStateOptions<T = any> = {
 
 export function describeComputed<T = any>(
   name: string,
-  config: MadroneDescriptor,
+  config: MadroneComputedDescriptor,
   options?: MadroneStateOptions<T>
 ) {
   let getter;
@@ -55,7 +55,7 @@ export function describeComputed<T = any>(
 
 export function describeProperty(
   name: string,
-  config: PropertyDescriptor,
+  config: MadronePropertyDescriptor,
   options?: MadroneStateOptions
 ) {
   const tg = { value: config.value };
@@ -66,6 +66,7 @@ export function describeProperty(
     onSet: options?.reactive?.onSet,
     onDelete: options?.reactive?.onDelete,
     needsProxy: options?.reactive?.needsProxy,
+    deep: config.deep ?? options?.reactive?.deep,
   });
 
   return {
@@ -89,16 +90,11 @@ export function describeProperty(
   };
 }
 
-export function defineComputed(target, name: string, config, options) {
+export function defineComputed(target, name: string, config: MadroneComputedDescriptor, options) {
   Object.defineProperty(target, name, describeComputed(name, config, options));
 }
 
-export function defineProperty(
-  target,
-  name: string,
-  config: { value?: any; enumerable?: boolean; configurable?: boolean },
-  options?
-) {
+export function defineProperty(target, name: string, config: MadronePropertyDescriptor, options?) {
   Object.defineProperty(target, name, describeProperty(name, config, options));
 }
 

--- a/src/integrations/MadroneVue2.ts
+++ b/src/integrations/MadroneVue2.ts
@@ -1,6 +1,7 @@
 import { objectAccessed } from '@/global';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
+import MStateDefault from './MadroneState';
 import * as MadroneState from './MadroneState';
 
 type KeyType = string | number | symbol;
@@ -106,6 +107,7 @@ export default (opts) => {
   }
 
   return {
+    toRaw: MStateDefault.toRaw,
     watch: MadroneState.watch,
     describeProperty,
     defineProperty,

--- a/src/integrations/MadroneVue3.ts
+++ b/src/integrations/MadroneVue3.ts
@@ -1,6 +1,7 @@
 import { objectAccessed } from '@/global';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
+import MStateDefault from './MadroneState';
 import * as MadroneState from './MadroneState';
 
 type KeyType = string | number | symbol;
@@ -108,6 +109,7 @@ export default ({ reactive, toRaw } = {} as any) => {
   }
 
   return {
+    toRaw: MStateDefault.toRaw,
     watch: MadroneState.watch,
     describeProperty,
     defineProperty,

--- a/src/integrations/__spec__/testClass.ts
+++ b/src/integrations/__spec__/testClass.ts
@@ -299,6 +299,38 @@ describe('reactive classes', () => {
 
     expect(course.everyone).toEqual(['Olivia', 'Carl']);
   });
+
+  it('Can create a shallow reactive property', async () => {
+    class TestObj {
+      @reactive val: Record<string, any>;
+      constructor() {
+        this.val = { one: { two: { string: 'hello' } } };
+      }
+    }
+
+    const object = new TestObj();
+    let calls = 0;
+
+    Madrone.watch(
+      () => object.val,
+      () => {
+        calls += 1;
+      }
+    );
+
+    expect(calls).toEqual(0);
+    object.val.one = { ...object.val.one };
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
+    expect(calls).toEqual(0);
+
+    object.val = { ...object.val };
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
+    expect(calls).toEqual(1);
+  });
 });
 
 describe('class mixins', () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,15 +1,23 @@
 export interface MadroneDescriptor extends PropertyDescriptor {
+  /** Cache a computed property */
   cache?: boolean;
+  /** Define a deeply reactive property */
+  deep?: boolean;
 }
+export type MadroneComputedDescriptor = Pick<
+  MadroneDescriptor,
+  'get' | 'set' | 'cache' | 'enumerable' | 'configurable'
+>;
+export type MadronePropertyDescriptor = Pick<
+  MadroneDescriptor,
+  'configurable' | 'enumerable' | 'value' | 'deep'
+>;
 
 export interface MadroneDescriptorMap {
   [key: string]: MadroneDescriptor;
 }
 
-export type DecoratorDescriptorType = Omit<
-  PropertyDescriptor,
-  'get' | 'set' | 'writable' | 'value'
->;
+export type DecoratorDescriptorType = Omit<MadroneDescriptor, 'get' | 'set' | 'writable' | 'value'>;
 export type DecoratorOptionType = {
   descriptors?: DecoratorDescriptorType;
 };
@@ -23,23 +31,13 @@ export interface Integration {
   defineProperty: (
     target: any,
     name: string,
-    config: {
-      value?: any;
-      enumerable?: boolean;
-      configurable?: boolean;
-    },
+    config: MadronePropertyDescriptor,
     options?: any
   ) => any;
   defineComputed: (
     target: any,
     name: string,
-    config: {
-      get: () => any;
-      set?: (any) => void;
-      cache?: boolean;
-      enumerable?: boolean;
-      configurable?: boolean;
-    },
+    config: MadroneComputedDescriptor,
     options?: any
   ) => any;
   toRaw?: <T>(target: T) => T;
@@ -48,10 +46,14 @@ export interface Integration {
     handler: (val: T, old?: T) => any,
     options?: WatcherOptions
   ) => () => void;
-  describeComputed?: (name: string, config: MadroneDescriptor, options?: any) => PropertyDescriptor;
+  describeComputed?: (
+    name: string,
+    config: MadroneComputedDescriptor,
+    options?: any
+  ) => PropertyDescriptor;
   describeProperty?: (
     name: string,
-    config: PropertyDescriptor,
+    config: MadronePropertyDescriptor,
     options?: any
   ) => PropertyDescriptor;
 }

--- a/src/reactivity/Reactive.ts
+++ b/src/reactivity/Reactive.ts
@@ -16,7 +16,7 @@ export default function Reactive<T extends object>(target: T, options?: Reactive
   if (isReactive(target)) return target;
 
   const opts = options || {};
-  const newOptions = { deep: true, ...opts };
+  const newOptions = { ...opts, deep: opts?.deep ?? true };
   const type = Reactive.getStringType(target);
 
   // make sure we're looking at something we can observe

--- a/src/reactivity/__spec__/reactive_object.spec.ts
+++ b/src/reactivity/__spec__/reactive_object.spec.ts
@@ -112,7 +112,7 @@ describe('Reactive objects', () => {
       expect(isReactive(obs.one.two.string)).toEqual(false);
     });
 
-    it('creates can be a shallow Reactive', () => {
+    it('can be shallow Reactive', () => {
       const object = { one: { two: { string: 'hello' } } };
       const obs = Reactive(object, { deep: false });
 

--- a/src/reactivity/global.ts
+++ b/src/reactivity/global.ts
@@ -23,7 +23,9 @@ let TASK_QUEUE = [];
 /** The id of the timeout that will handle all scheduled tasks */
 let SCHEDULER_ID = null;
 
+/** Check if the current target has a proxy associated with it */
 export const isReactiveTarget = (target) => TARGET_TO_PROXY.has(target);
+/** Check if the current proxy has a target object */
 export const isReactive = (trk) => PROXY_TO_TARGET.has(trk);
 export const getReactive = (target) => TARGET_TO_PROXY.get(target);
 export const getTarget = (tracker) => PROXY_TO_TARGET.get(tracker);

--- a/src/reactivity/typeHandlers.ts
+++ b/src/reactivity/typeHandlers.ts
@@ -134,6 +134,7 @@ function defaultHandlers(options: ReactiveOptions) {
       optionHasOwnKeys(options, target);
       return Reflect.ownKeys(target);
     },
+    getPrototypeOf: (target) => Object.getPrototypeOf(target),
   };
 }
 


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- expose `toRaw` to unwrap proxies
- add `reactive.shallow` descriptor to prevent deep proxies
- simplify types

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
