### PR TITLE
chore: export interfaces and remove deep watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
     "madrone",
     "vue"
   ],
-  "dependencies": {
-    "lodash": "4.17.21"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^29.5.4",
     "@types/lodash": "^4.14.197",
@@ -55,6 +53,7 @@
     "eslint-plugin-unicorn": "^48.0.1",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
+    "lodash": "4.17.21",
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "tsc-alias": "^1.8.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  lodash:
-    specifier: 4.17.21
-    version: 4.17.21
-
 devDependencies:
   '@types/jest':
     specifier: ^29.5.4
@@ -49,6 +44,9 @@ devDependencies:
   jest-environment-jsdom:
     specifier: ^29.6.4
     version: 29.6.4
+  lodash:
+    specifier: 4.17.21
+    version: 4.17.21
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
@@ -3621,6 +3619,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,9 @@ const Madrone = {
 };
 
 export default Madrone;
-export * from './integrations';
-export * from './decorate';
+export * from '@/integrations';
+export * from '@/interfaces';
+export * from '@/decorate';
 export { toRaw } from '@/global';
-export { merge, applyClassMixins } from './util';
+export { merge, applyClassMixins } from '@/util';
 export { watch, auto } from '@/auto';

--- a/src/integrations/MadroneState.ts
+++ b/src/integrations/MadroneState.ts
@@ -1,5 +1,5 @@
 import { objectAccessed } from '@/global';
-import { MadroneComputedDescriptor, MadronePropertyDescriptor } from '@/interfaces';
+import { Integration, MadroneComputedDescriptor, MadronePropertyDescriptor } from '@/interfaces';
 import { Computed, Reactive, Watcher, toRaw } from '@/reactivity';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
@@ -98,7 +98,7 @@ export function defineProperty(target, name: string, config: MadronePropertyDesc
   Object.defineProperty(target, name, describeProperty(name, config, options));
 }
 
-export default {
+const MadroneState: Integration = {
   toRaw,
   watch: Watcher,
   describeProperty,
@@ -107,4 +107,5 @@ export default {
   defineComputed,
 };
 
+export default MadroneState;
 export { Watcher as watch } from '@/reactivity';

--- a/src/integrations/MadroneVue2.ts
+++ b/src/integrations/MadroneVue2.ts
@@ -1,6 +1,7 @@
 import { objectAccessed } from '@/global';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
+import { Integration } from '@/interfaces';
 import MStateDefault from './MadroneState';
 import * as MadroneState from './MadroneState';
 
@@ -9,7 +10,7 @@ type KeyType = string | number | symbol;
 const FORBIDDEN = new Set<KeyType>(['__proto__', '__ob__']);
 const VALUE = 'value';
 
-export default (opts) => {
+export default function MadroneVue2(opts): Integration {
   const { observable, set } = opts;
   // store all reactive properties
   const reactiveMappings = new WeakMap();
@@ -114,4 +115,4 @@ export default (opts) => {
     describeComputed,
     defineComputed,
   };
-};
+}

--- a/src/integrations/MadroneVue3.ts
+++ b/src/integrations/MadroneVue3.ts
@@ -1,6 +1,7 @@
 import { objectAccessed } from '@/global';
 import { ReactiveOptions } from '@/reactivity/interfaces';
 import { ObservableHooksType } from '@/reactivity/Observer';
+import type { Integration } from '@/interfaces';
 import MStateDefault from './MadroneState';
 import * as MadroneState from './MadroneState';
 
@@ -14,7 +15,7 @@ const reactiveSet = (item) => {
   item[VALUE] += 1;
 };
 
-export default ({ reactive, toRaw } = {} as any) => {
+export default function MadroneVue3({ reactive, toRaw } = {} as any): Integration {
   const obToRaw = toRaw ?? ((val) => val);
   // store all reactive properties
   const reactiveMappings = new WeakMap<object, Map<string, { value: number }>>();
@@ -116,4 +117,4 @@ export default ({ reactive, toRaw } = {} as any) => {
     describeComputed,
     defineComputed,
   };
-};
+}

--- a/src/integrations/__spec__/testAuto.ts
+++ b/src/integrations/__spec__/testAuto.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep';
 import lodashSet from 'lodash/set';
 import Madrone from '../../index';
 import { delay } from '@/test/util';
@@ -465,12 +466,11 @@ export default function testAuto(name, integration) {
       });
 
       Madrone.watch(
-        () => instance.value,
+        () => cloneDeep(instance.value),
         (newVal, oldVal) => {
           newVals.push(newVal);
           oldVals.push(oldVal);
-        },
-        { deep: true }
+        }
       );
 
       lodashSet(instance, 'value.child1', 'hello');

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,7 +23,6 @@ export type DecoratorOptionType = {
 };
 
 export type WatcherOptions = {
-  deep?: boolean;
   immediate?: boolean;
 };
 

--- a/src/reactivity/Watcher.ts
+++ b/src/reactivity/Watcher.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep';
 import { WatcherOptions } from '@/interfaces';
 import Observer from './Observer';
 
@@ -14,14 +13,8 @@ export default function Watcher<T>(
   handler: (val?: T, old?: T) => any,
   options?: WatcherOptions
 ) {
-  let getter = get;
-
-  if (options?.deep) {
-    getter = () => cloneDeep(get());
-  }
-
   const obs = Observer({
-    get: getter,
+    get,
     onChange: ({ value, prev }) => handler(value, prev),
   });
 

--- a/src/reactivity/__spec__/watcher.spec.ts
+++ b/src/reactivity/__spec__/watcher.spec.ts
@@ -1,7 +1,8 @@
+import cloneDeep from 'lodash/cloneDeep';
+import { delay } from '@/test/util';
 import Computed from '../Computed';
 import Watcher from '../Watcher';
 import Reactive from '../Reactive';
-import { delay } from '@/test/util';
 
 describe('Watcher', () => {
   it('has callback when tracked value changed', async () => {
@@ -84,13 +85,10 @@ describe('Watcher', () => {
     const oldValues = [];
 
     Watcher(
-      () => tracked,
+      () => cloneDeep(tracked),
       (val, old) => {
         newValues.push(val);
         oldValues.push(old);
-      },
-      {
-        deep: true,
       }
     );
 


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- export interfaces so ts doesn't throw errors
- remove deep watcher because it's just using lodash's `cloneDeep`

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->
This helps improve types and should make the package smaller (we have no external dependencies now 🎉).

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
