### PR TITLE
chore: use promise resolve instead of setTimeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "vitest",
     "test-ci": "CI=true NODE_ENV=test vitest run --coverage",
     "docs": "typedoc --entryPoints src/index.ts",
-    "cleanup": "rm -rf ./dist && rm -rf ./types",
+    "cleanup": "rm -rf ./dist/* && rm -rf ./types/*",
     "cov": "CI=true NODE_ENV=test vitest run --coverage && open coverage/lcov-report/index.html",
     "build": "vite build",
     "build-types": "tsc -p ./tsconfig.types.json && tsc-alias -p tsconfig.types.json",

--- a/src/reactivity/global.ts
+++ b/src/reactivity/global.ts
@@ -42,7 +42,9 @@ export const addReactive = (target, proxy) => {
 };
 const doTasksIfNeeded = () => {
   if (SCHEDULER_ID === null) {
-    SCHEDULER_ID = setTimeout(() => {
+    SCHEDULER_ID = Symbol('scheduler');
+
+    Promise.resolve().then(() => {
       const queue = TASK_QUEUE;
 
       TASK_QUEUE = [];


### PR DESCRIPTION
<!-- Remove all rows that don't apply to this PR --->
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
<!-- Describe your changes in a brief, bullet list --->
- use `Promise.resolve` instead of `setTimeout` to handle the "nextTick"
- don't destroy the `dist` or `types` folders so it's easier to use `pnpm link`

### 📢 Additional Info:
<!-- Give some more context... Why is this needed? --->

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
