### PR TITLE
chore: calling workflows need to allow all permissions child workflows request

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -2,6 +2,8 @@ name: Draft Release
 
 permissions:
   contents: write
+  pull-requests: write
+
 
 on:
   push:


### PR DESCRIPTION
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...)                                     |  👷  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
add permissions to top-workflow that all the child workflows and actions need

### 📢 Additional Info:
- Github is giving me the requirements ONE. AT. A. TIME. 😬 

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [ ] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
