### PR TITLE
fix: keep @reactive overrides @computeds through multiple mixin levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`@classMixin`**: A `@reactive` property overriding a deeper ancestor's `@computed` is no longer left getter-only on leaf classes composed through more than one mixin level (writes previously threw `TypeError: Cannot set property X which has only a getter`).
+
 ## [2.0.0] - 2026-04-20
 
 ### Breaking

--- a/src/__spec__/classMixin.spec.ts
+++ b/src/__spec__/classMixin.spec.ts
@@ -238,4 +238,67 @@ describe('classMixin', () => {
       stop();
     });
   });
+
+  describe('multi-level chains: @reactive overriding a deeper @computed', () => {
+    // A two-level mixin chain: GrandParent declares a getter-only @computed,
+    // Parent overrides it as a writable @reactive, and Leaf composes Parent.
+    // The prototype merge copies GrandParent's getter-only accessor down onto
+    // each descendant prototype; the metadata replay must still install the
+    // @reactive override on the leaf, or writes to leaf instances throw
+    // "Cannot set property ... which has only a getter".
+    it('keeps the property writable on a leaf that inherits the override without redeclaring', () => {
+      class GrandParent {
+        @computed get amountTransferred(): number { return 0; }
+      }
+
+      @classMixin(GrandParent)
+      class Parent {
+        @reactive amountTransferred: number;
+      }
+      interface Parent extends GrandParent {}
+
+      @classMixin(Parent)
+      class Leaf {}
+      interface Leaf extends Parent {}
+
+      const leaf = new Leaf();
+      const write = () => {
+        leaf.amountTransferred = 5;
+      };
+
+      expect(write).not.toThrow();
+      expect(leaf.amountTransferred).toEqual(5);
+    });
+
+    it('wires the inherited override into the reactive graph on the leaf', async () => {
+      class GrandParent {
+        @computed get progress(): number { return 0; }
+      }
+
+      @classMixin(GrandParent)
+      class Parent {
+        @reactive progress: number;
+      }
+      interface Parent extends GrandParent {}
+
+      @classMixin(Parent)
+      class Leaf {}
+      interface Leaf extends Parent {}
+
+      const leaf = new Leaf();
+      const seen: number[] = [];
+      const stop = watch(() => leaf.progress, (val) => {
+        seen.push(val);
+      });
+
+      leaf.progress = 1;
+      await Promise.resolve();
+      leaf.progress = 2;
+      await Promise.resolve();
+
+      expect(leaf.progress).toEqual(2);
+      expect(seen).toEqual([1, 2]);
+      stop();
+    });
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -217,6 +217,21 @@ export function applyClassMixins(
 
   for (const { entry, originProto } of resolved.values()) {
     if (entry.kind === 'reactive') {
+      // The prototype merge above may have copied a getter-only @computed
+      // accessor for this key down from a deeper mixin (a multi-level chain
+      // where an ancestor declared it @computed and a nearer mixin overrode it
+      // @reactive). This key resolved to @reactive in the metadata, which is
+      // authoritative here - base's own keys are already excluded from
+      // `resolved`, so any descriptor present is a merge artifact, not a
+      // base-declared accessor. Drop it first; otherwise installLazyReactive's
+      // "leave an existing own accessor alone" guard preserves the stale
+      // getter-only and writes throw.
+      const merged = Object.getOwnPropertyDescriptor(base.prototype, entry.key);
+
+      if (merged && !isMixinInstalled(merged)) {
+        delete (base.prototype as Record<string | symbol, unknown>)[entry.key];
+      }
+
       installLazyReactive(base.prototype, entry.key, entry.options);
       baseMeta.push(entry);
     } else {


### PR DESCRIPTION
| Type       | Description                                                                | Icon | Changelog |
| ---------- | ---------------------------------------------------------------------------| :--: | :-------: |
| `fix`       | Fixes an issue                                                            |  🐛  |    ✅     |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:
- Fixed @classMixin so a @reactive property that overrides a @computed from a deeper ancestor stays writable on leaf classes composed through more than one mixin level.
- Added regression tests covering both writability and reactive tracking on such a leaf.
- Added a CHANGELOG.md entry under Unreleased. (I think releases are separate PRs here?)

### 📢 Additional Info:
When you stack mixins more than one level deep, and a middle class turns a base's getter-only `@computed` into a writable `@reactive`, the **leaf** class silently lost the override - writes threw at runtime:

```ts
class Base {
  @computed get amount() { return 0; }   // getter-only
}

@classMixin(Base)
class Middle {
  @reactive amount: number;              // override -> writable
}

@classMixin(Middle)
class Leaf {}                            // inherits, doesn't redeclare

new Leaf().amount = 5;
// before: TypeError: Cannot set property amount ... which has only a getter
// after:  works
```

**Why it happened:** when classes are merged, the deeper getter-only `@computed` accessor is copied down onto each descendant's prototype. The metadata correctly resolved the key to `@reactive`, but the lazy-reactive install skipped it - it couldn't tell the copied-down accessor apart from one the leaf declared itself - and left the getter-only in place. The fix drops that copied-down accessor before installing the reactive one, so the resolved `@reactive` override wins.

The 2-level case (`Middle` itself) already worked; only leaves one or more levels **below** the override were broken.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [x] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
