### PR TITLE
chore: release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.1] - 2026-06-30
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madronejs/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Object composition and reactivity framework.",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
| Type | Description | Icon |
| ---- | ----------- | :--: |
| `chore` | Release 2.0.1 | 👷 |

### 🛠️ Changes:
- Bump version `2.0.0` -> `2.0.1`
- Promote the `Unreleased` changelog section to `## [2.0.1] - 2026-06-30`

### 📢 Additional Info:
Patch release for the multi-level mixin reactivity fix merged in #76 - a `@reactive` property overriding a deeper ancestor's `@computed` no longer stays getter-only on leaf classes composed through more than one mixin level. No other changes since 2.0.0.

### 📚 Bookkeeping:

**Testing**:
- [x] Full suite green (435 tests); `pnpm build` clean

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [x] Release Notes: `CHANGELOG.md` entry dated under `2.0.1`
