### PR TITLE
ci: add manual npm publish workflow + modernize PR validation actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: write   # to create the tag + release
-  id-token: write   # for npm provenance
+  id-token: write   # for npm provenance + trusted publishing (OIDC)
 
 jobs:
   publish:
@@ -32,6 +32,10 @@ jobs:
       - run: corepack enable
 
       - run: pnpm install --frozen-lockfile
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Verify
         run: pnpm all   # build-types + lint + test-ci
@@ -52,11 +56,11 @@ jobs:
         if: ${{ inputs.dry_run }}
         run: npm publish --access public --tag "${{ inputs.dist_tag }}" --provenance --dry-run
 
+      # Auth comes from the GitHub OIDC token, not a stored secret: the package
+      # must have madronejs/madrone -> publish.yml registered as a trusted publisher on npm.
       - name: Publish
         if: ${{ !inputs.dry_run }}
         run: npm publish --access public --tag "${{ inputs.dist_tag }}" --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag + GitHub release
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and pack only; do not publish"
+        type: boolean
+        default: true
+      dist_tag:
+        description: "npm dist-tag"
+        type: string
+        default: latest
+
+permissions:
+  contents: write   # to create the tag + release
+  id-token: write   # for npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - run: corepack enable
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify
+        run: pnpm all   # build-types + lint + test-ci
+
+      - name: Build artifacts
+        run: pnpm build-all
+
+      - name: Guard against republishing an existing version
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+            echo "::error::$NAME@$VER is already published"; exit 1
+          fi
+          echo "VER=$VER" >> "$GITHUB_ENV"
+
+      - name: Publish (dry run)
+        if: ${{ inputs.dry_run }}
+        run: npm publish --access public --tag "${{ inputs.dist_tag }}" --provenance --dry-run
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
+        run: npm publish --access public --tag "${{ inputs.dist_tag }}" --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag + GitHub release
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag "v$VER"
+          git push origin "v$VER"
+          gh release create "v$VER" --title "v$VER" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout the commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
 
@@ -37,10 +37,10 @@ jobs:
         shell: bash
         run: |
           corepack enable
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-install.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
| Type       | Description                                          | Icon | Changelog |
| ---------- | ---------------------------------------------------- | :--: | :-------: |
| `ci`        | The Continuous Integration system is being updated  |  ⚙️  |           |
-------------------------------------------------------------------------------------------------------------

### 🛠️ Changes:

- Add `.github/workflows/publish.yml`: a manual (`workflow_dispatch`) workflow that builds, verifies, and publishes the `package.json` version to npm.
  - `dry_run` input defaults to **true**, so an accidental run only builds and packs - it never publishes.
  - Runs `pnpm all` (build-types + lint + test-ci) and `pnpm build-all` before publishing.
  - Guards against republishing an already-published version.
  - Authenticates to npm via **trusted publishing (OIDC)** - no stored `NPM_TOKEN` secret. Uses the workflow's `id-token: write` identity.
  - Upgrades npm to a version that supports trusted publishing (Node 22 ships npm 10.x; OIDC needs npm >= 11.5.1).
  - On a real run: publishes with npm provenance, then creates the `vX.Y.Z` tag and a GitHub Release.
- Modernize `.github/workflows/validate-pr.yml`: bump `actions/checkout`, `actions/setup-node`, and `actions/cache` from `@v3` to `@v4`, and replace the disabled `::set-output` command with `>> "$GITHUB_OUTPUT"`.

### 📢 Additional Info:

madrone had no npm publish automation - `2.0.0` and `2.0.1` were published by hand, leaving no git tags or GitHub Releases. `publish.yml` gives maintainers a one-click release from the Actions UI while keeping a safety interlock: dry-run is the default, and the publish/tag/release steps are gated behind explicitly unchecking it.

The `validate-pr.yml` changes clear GitHub's deprecation warnings - `@v3` actions run on the retired Node 16 runtime, and `::set-output` was disabled by GitHub in 2023.

**Prerequisite (before a real, non-dry-run publish):** register a trusted publisher on npm for `@madronejs/core` (Settings -> Trusted Publisher -> GitHub Actions -> org `madronejs`, repo `madrone`, workflow `publish.yml`). No secret needs to be added to GitHub. Dry-run works without any of this, since it never authenticates.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [ ] N/A - CI/workflow-only change; verified by YAML parse and a dry-run of `publish.yml`

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [x] Release Notes: not required (`ci` type has no changelog requirement)
