### PR TITLE
chore: release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-06-30
+
+### Changed
+
+- Maintenance release: added an npm publish workflow (CI only) and updated development dependencies. No changes to the published API or runtime behavior.
+
 ## [2.0.1] - 2026-06-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madronejs/core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Object composition and reactivity framework.",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
| Type       | Description                            | Icon | Changelog |
| ---------- | -------------------------------------- | :--: | :-------: |
| `chore`     | Internal stuff (feat/fix/debt/etc...) |  👷  |           |

### 🛠️ Changes:

- Bump version `2.0.1` -> `2.0.2`.
- Add `CHANGELOG.md` entry for `2.0.2`.

### 📢 Additional Info:

Maintenance release off `main`. Everything since `2.0.1` is CI/dev-only - the npm publish workflow (#78) and the low-risk dev-dependency bumps (#79). The published `dist/`/`types/` are unchanged from `2.0.1`, so there is no consumer-facing API or runtime change.

The two risky updates from the dependency audit (`eslint-plugin-unicorn` #80 and the pending Vite 8 work) are intentionally **not** in this release - they are slated for a later version (2.0.3).

After merge, a maintainer runs the **Publish to npm** workflow to ship `2.0.2` (tag + GitHub Release). Prerequisite: the npm trusted publisher must be registered for `@madronejs/core`.

### 📚 Bookkeeping:

**Testing (if applicable)**:
- [x] N/A - version + changelog only; no code change.

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [x] Release Notes: CHANGELOG.md updated in this PR
