### PR TITLE
fix: preserve a leaf's own plain override of a mixed-in @reactive/@computed

### DIFF
--- a/src/__spec__/classMixin.spec.ts
+++ b/src/__spec__/classMixin.spec.ts
@@ -301,4 +301,78 @@ describe('classMixin', () => {
       stop();
     });
   });
+
+  describe('multi-level chains: a plain member overriding a deeper @reactive', () => {
+    // Inverse of #76: a leaf's undecorated method/getter override of a base
+    // @reactive, through more than one mixin level, must win over the replay.
+    it('keeps a leaf plain-method override of a base @reactive field through two mixin levels', () => {
+      class GrandParent {
+        @reactive transform: (x: number) => number;
+      }
+
+      @classMixin(GrandParent)
+      class Parent {}
+      interface Parent extends GrandParent {}
+
+      @classMixin(Parent)
+      class Leaf {
+        transform(x: number) {
+          return x * 2;
+        }
+      }
+      interface Leaf extends Parent {}
+
+      const leaf = new Leaf();
+
+      expect(typeof leaf.transform).toEqual('function');
+      expect(leaf.transform(21)).toEqual(42);
+    });
+
+    it('keeps a leaf plain-getter override of a base @reactive field through two mixin levels', () => {
+      class GrandParent {
+        @reactive label: string;
+      }
+
+      @classMixin(GrandParent)
+      class Parent {}
+      interface Parent extends GrandParent {}
+
+      @classMixin(Parent)
+      class Leaf {
+        get label(): string {
+          return 'leaf';
+        }
+      }
+      interface Leaf extends Parent {}
+
+      const leaf = new Leaf();
+
+      expect(leaf.label).toEqual('leaf');
+    });
+
+    it('still installs the reactive when the leaf does NOT redeclare (preserves #76)', () => {
+      class GrandParent {
+        @computed get amount(): number {
+          return 0;
+        }
+      }
+
+      @classMixin(GrandParent)
+      class Parent {
+        @reactive amount: number;
+      }
+      interface Parent extends GrandParent {}
+
+      @classMixin(Parent)
+      class Leaf {}
+      interface Leaf extends Parent {}
+
+      const leaf = new Leaf();
+
+      expect(() => {
+        leaf.amount = 5;
+      }).not.toThrow();
+      expect(leaf.amount).toEqual(5);
+    });
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -165,6 +165,12 @@ export function applyClassMixins(
   mixins: Constructor[],
   baseMetadata?: DecoratorMetadata,
 ): void {
+  // Snapshot the leaf's own prototype members before the merge below overwrites
+  // them, so an undecorated override can be kept out of the reactive replay.
+  const baseProtoOwnKeys = new Set(
+    Reflect.ownKeys(base.prototype).filter((key) => key !== 'constructor'),
+  );
+
   // Build the merged descriptor map for the prototype merge, but strip any
   // lazy-mixin accessors that came from a mixin's prototype. They belong to
   // that mixin's own installation — re-copying them onto `base.prototype`
@@ -216,6 +222,9 @@ export function applyClassMixins(
   }
 
   for (const key of baseOwnKeys) resolved.delete(key);
+
+  // A member the leaf declares itself wins over a mixed-in reactive/computed.
+  for (const key of baseProtoOwnKeys) resolved.delete(key);
 
   for (const { entry, originProto } of resolved.values()) {
     if (entry.kind === 'reactive') {


### PR DESCRIPTION
## Summary

Follow-up to #76. #76 made a nearer `@reactive` beat a deeper `@computed` across multiple mixin levels, but its reactive replay also clobbered the **opposite** shape: a leaf that overrides a base `@reactive`/`@computed` with a plain (undecorated) method or getter, composed through more than one mixin level, had a lazy-reactive accessor installed over its own member — which read back as `undefined` and silently broke the override.

```ts
class Base {
  @reactive transform: (x: number) => number;   // reactive field
}

@classMixin(Base)
class Mid {}

@classMixin(Mid)
class Leaf {
  transform(x: number) { return x * 2; }         // plain method override, 2 levels down
}

typeof new Leaf().transform;
// before: 'undefined'   (own member clobbered by the reactive replay)
// after:  'function'
```

## Fix

`applyClassMixins` now snapshots the leaf's own prototype members **before** the mixin merge and excludes them from the `@reactive`/`@computed` replay, so a class's own declaration (decorated or not) always wins. Capturing before the merge matters: afterwards the prototype also carries copied-down `@computed` artifacts, which must still be replayed — so a leaf-authored member and a merge artifact are indistinguishable at that point.

The #76 behaviour is unchanged: a leaf that redeclares nothing still gets the reactive installed.

## Testing

- Added regression tests to `classMixin.spec.ts`: a plain-method override and a plain-getter override of a base `@reactive` through two mixin levels (both failed before this change), plus a test that locks in the #76 case.
- Full suite green (438 tests).