### PR TITLE
fix: apply object/array writes before notifying observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Reactivity**: Object/array proxy `set` and `deleteProperty` traps now apply the mutation *before* notifying observers, matching the Map/Set handlers and Vue's own ordering. Previously, observers that ran synchronously on notification (e.g. Vue `flush: 'sync'` watchers via the `MadroneVue3` integration) read the pre-write value and could settle permanently stale, missing single in-place writes until an unrelated change re-dirtied them. Failed writes (frozen targets, non-writable properties) no longer emit notifications.
+
 ## [2.0.4] - 2026-07-02
 
 ### Fixed

--- a/src/integrations/__spec__/vue3.spec.ts
+++ b/src/integrations/__spec__/vue3.spec.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
 import * as Vue from 'vue3';
+import Madrone from '../../index';
 import MadroneVue3 from '../MadroneVue3';
 import MadroneVue from '../vue';
 import testAll from './testAll';
@@ -14,6 +17,46 @@ const vueOptions = {
 testAll('Vue3', integration);
 testVue('Vue3', integration, vueOptions);
 testVueCollections('Vue3', integration, vueOptions);
+
+describe('Vue3 sync watchers', () => {
+  beforeAll(() => {
+    Madrone.use(integration);
+  });
+  afterAll(() => {
+    Madrone.unuse(integration);
+  });
+
+  it('a flush:sync watcher reads the written value on an in-place write', () => {
+    const state = Madrone.auto({ name: 'Event 1' });
+    const seen: string[] = [];
+    const stop = Vue.watch(() => state.name, (val) => {
+      seen.push(val);
+    }, { flush: 'sync' });
+
+    state.name = 'Event 2';
+
+    expect(seen).toEqual(['Event 2']);
+    stop();
+  });
+
+  it('a flush:sync watcher on a Vue computed does not go permanently stale', () => {
+    const state = Madrone.auto({ name: 'a' });
+    const signature = Vue.computed(() => state.name);
+    const seen: string[] = [];
+    const stop = Vue.watch(signature, (val) => {
+      seen.push(val);
+    }, { flush: 'sync' });
+
+    state.name = 'b';
+
+    // Pre-fix, the sync watcher re-evaluated the computed mid-set-trap, read the
+    // old value, and settled clean — leaving the computed stale even after the
+    // write landed, with no later notification to recover it.
+    expect(seen).toEqual(['b']);
+    expect(signature.value).toBe('b');
+    stop();
+  });
+});
 
 describe('MadroneVue pre-configured module', () => {
   it('exports a valid integration', () => {

--- a/src/reactivity/__spec__/reactive.spec.ts
+++ b/src/reactivity/__spec__/reactive.spec.ts
@@ -254,6 +254,65 @@ describe('Reactive', () => {
     });
   });
 
+  describe('notification ordering', () => {
+    it('applies the write before calling onSet', () => {
+      let seenDuringHook = null;
+      const state = Reactive<{ name: string }>({ name: 'old' }, {
+        onSet: ({ target, key }) => {
+          seenDuringHook = target[key];
+        },
+      });
+
+      state.name = 'new';
+
+      expect(seenDuringHook).toBe('new');
+    });
+
+    it('removes the key before calling onDelete', () => {
+      let presentDuringHook = null;
+      const state = Reactive<{ a?: number }>({ a: 1 }, {
+        onDelete: ({ target, key }) => {
+          presentDuringHook = key in target;
+        },
+      });
+
+      delete state.a;
+
+      expect(presentDuringHook).toBe(false);
+    });
+
+    it('does not notify when the write fails', () => {
+      let setCount = 0;
+      const frozen = Object.freeze({ name: 'old' });
+      const state = Reactive<{ name: string }>(frozen, {
+        onSet: () => {
+          setCount += 1;
+        },
+      });
+
+      // In strict mode a set trap returning false throws
+      expect(() => {
+        state.name = 'new';
+      }).toThrow(TypeError);
+      expect(setCount).toBe(0);
+    });
+
+    it('does not notify when the delete fails', () => {
+      let deleteCount = 0;
+      const sealed = Object.seal({ a: 1 });
+      const state = Reactive<{ a?: number }>(sealed, {
+        onDelete: () => {
+          deleteCount += 1;
+        },
+      });
+
+      expect(() => {
+        delete state.a;
+      }).toThrow(TypeError);
+      expect(deleteCount).toBe(0);
+    });
+  });
+
   describe('onDelete callback', () => {
     it('calls onDelete when property is deleted', () => {
       let deleteCount = 0;

--- a/src/reactivity/typeHandlers.ts
+++ b/src/reactivity/typeHandlers.ts
@@ -35,13 +35,23 @@ const optionGet = (options: ReactiveOptions, target, key, receiver) => {
   }
 };
 
+// Write first, then notify: observers woken synchronously (e.g. Vue sync watchers
+// via the Vue3 integration's onSet) must read the already-written value, and a
+// failed write must not notify at all. Pre-write state is captured for change
+// detection. This matches the Map/Set handlers below, which also mutate before
+// calling targetChanged.
 const optionSet = (options: ReactiveOptions, target, key, value) => {
+  const wasPresent = key in target;
   const curr = target[key];
   const isArray = Array.isArray(target);
+  const didSet = Reflect.set(target, key, value);
+
+  if (!didSet) return false;
+
   let isValueChanged = false;
   let isKeysChanged = false;
 
-  if (!(key in target)) {
+  if (!wasPresent) {
     targetChanged(target, KEYS_SYMBOL);
     isKeysChanged = true;
 
@@ -61,9 +71,15 @@ const optionSet = (options: ReactiveOptions, target, key, value) => {
       name: options.name, target, key, value, keysChanged: isKeysChanged, valueChanged: isValueChanged,
     }));
   }
+
+  return true;
 };
 
 const optionDelete = (options: ReactiveOptions, target, key) => {
+  const didDelete = Reflect.deleteProperty(target, key);
+
+  if (!didDelete) return false;
+
   targetChanged(target, key);
   targetChanged(target, KEYS_SYMBOL);
 
@@ -73,6 +89,8 @@ const optionDelete = (options: ReactiveOptions, target, key) => {
       name: options.name, target, key, keysChanged: true,
     }));
   }
+
+  return true;
 };
 
 const optionHasOwnKeys = (options: ReactiveOptions, target, key?) => {
@@ -110,14 +128,8 @@ function defaultHandlers(options: ReactiveOptions) {
 
       return value;
     },
-    set: (target: object, propertyKey: PropertyKey, value: unknown) => {
-      optionSet(options, target, propertyKey, value);
-      return Reflect.set(target, propertyKey, value);
-    },
-    deleteProperty: (...args: Parameters<typeof Reflect.deleteProperty>) => {
-      optionDelete(options, ...args);
-      return Reflect.deleteProperty(...args);
-    },
+    set: (target: object, propertyKey: PropertyKey, value: unknown) => optionSet(options, target, propertyKey, value),
+    deleteProperty: (target: object, propertyKey: PropertyKey) => optionDelete(options, target, propertyKey),
     has: (target, key) => {
       optionHasOwnKeys(options, target);
       return Reflect.has(target, key);


### PR DESCRIPTION
The object/array proxy set and deleteProperty traps notified observers before Reflect.set / Reflect.deleteProperty ran, so observers that run synchronously on notification (e.g. Vue flush:'sync' watchers via the MadroneVue3 integration) read the pre-write value. A sync watcher on a Vue computed would re-evaluate mid-trap, see the old value, settle clean, and stay permanently stale after a single in-place write.

Write first, then notify, capturing pre-write state (key presence, old value) for change detection — matching the Map/Set handlers, which already mutate before calling targetChanged. Failed writes (frozen targets, non-writable properties) no longer emit notifications.

**Testing (if applicable)**:
- [x] Ran/wrote unit tests for this

**Checklist**
- [x] Assigned PR to myself
- [x] Added at least 1 person on the team as reviewer
- [x] Release Notes: PRs types that have the :spiral_notepad: next to them also require release notes to be added to the `CHANGELOG.md`
